### PR TITLE
[FIX] fix apply exception for solana/web3.js v78.1

### DIFF
--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -1,6 +1,6 @@
 import React, { useContext, useMemo } from 'react';
 import * as bip32 from 'bip32';
-import { Account, SystemProgram } from '@solana/web3.js';
+import { Account, SystemProgram, Transaction } from '@solana/web3.js';
 import nacl from 'tweetnacl';
 import {
   setInitialAccountInfo,
@@ -86,12 +86,15 @@ export class Wallet {
   };
 
   transferSol = async (destination, amount) => {
-    return await this.connection.sendTransaction(
+    const trx = new Transaction().add(
       SystemProgram.transfer({
         fromPubkey: this.publicKey,
         toPubkey: destination,
         lamports: amount,
-      }),
+      })
+    );
+    return await this.connection.sendTransaction(
+      trx,
       [this.account],
     );
   };


### PR DESCRIPTION
If we update solana/web3.js to v0.78.1, we will get exception when transfer SOL to others.

the main reason is that sendTransaction should use a Transaction not TransactionInstruction.

exception is:

notifications.js:43 Cannot read property 'apply' of undefined
sendTransaction @ notifications.js:43
async function (async)
sendTransaction @ notifications.js:22
onSubmit @ SendDialog.js:123
onSubmit @ SendDialog.js:51
onSubmit @ DialogForm.js:24
callCallback @ react-dom.development.js:188
invokeGuardedCallbackDev @ react-dom.development.js:237
invokeGuardedCallback @ react-dom.development.js:292
invokeGuardedCallbackAndCatchFirstError @ react-dom.development.js:306
executeDispatch @ react-dom.development.js:389
executeDispatchesInOrder @ react-dom.development.js:414
executeDispatchesAndRelease @ react-dom.development.js:3278
executeDispatchesAndReleaseTopLevel @ react-dom.development.js:3287
forEachAccumulated @ react-dom.development.js:3259
runEventsInBatch @ react-dom.development.js:3304
runExtractedPluginEventsInBatch @ react-dom.development.js:3514
handleTopLevel @ react-dom.development.js:3558
batchedEventUpdates$1 @ react-dom.development.js:21871
batchedEventUpdates @ react-dom.development.js:795
dispatchEventForLegacyPluginEventSystem @ react-dom.development.js:3568
attemptToDispatchEvent @ react-dom.development.js:4267
dispatchEvent @ react-dom.development.js:4189
unstable_runWithPriority @ scheduler.development.js:653
runWithPriority$1 @ react-dom.development.js:11039
discreteUpdates$1 @ react-dom.development.js:21887
discreteUpdates @ react-dom.development.js:806
dispatchDiscreteEvent @ react-dom.development.js:4168
