### PR TITLE
Add support for array format in account import and export

### DIFF
--- a/src/components/AddAccountDialog.js
+++ b/src/components/AddAccountDialog.js
@@ -8,7 +8,6 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormGroup from '@material-ui/core/FormGroup';
 import Switch from '@material-ui/core/Switch';
 import { Account } from '@solana/web3.js';
-import * as bs58 from 'bs58';
 import DialogForm from './DialogForm';
 
 export default function AddAccountDialog({ open, onAdd, onClose }) {
@@ -83,9 +82,14 @@ export default function AddAccountDialog({ open, onAdd, onClose }) {
   );
 }
 
+/**
+ * Returns an account object when given the private key
+ *
+ * @param {string} privateKey - the private key in array format
+ */
 function decodeAccount(privateKey) {
   try {
-    const a = new Account(bs58.decode(privateKey));
+    const a = new Account(JSON.parse(privateKey));
     return a;
   } catch (_) {
     return undefined;

--- a/src/components/ExportAccountDialog.js
+++ b/src/components/ExportAccountDialog.js
@@ -31,6 +31,7 @@ export default function ExportAccountDialog({ open, onClose }) {
           margin="normal"
           value={keyOutput}
         />
+        {isArrayFormat && <p>Developer feature - array format cannot be imported directly.</p>}
         <FormControlLabel
           control={
             <Switch

--- a/src/components/ExportAccountDialog.js
+++ b/src/components/ExportAccountDialog.js
@@ -13,6 +13,11 @@ import { useWallet } from '../utils/wallet';
 export default function ExportAccountDialog({ open, onClose }) {
   const wallet = useWallet();
   const [isHidden, setIsHidden] = useState(true);
+  const [isArrayFormat, setArrayFormat] = useState(false);
+
+  const keyOutput = isArrayFormat
+    ? `[${[].slice.call(wallet.provider.account.secretKey)}]`
+    : bs58.encode(wallet.provider.account.secretKey);
 
   return (
     <DialogForm open={open} onClose={onClose} fullWidth>
@@ -24,7 +29,16 @@ export default function ExportAccountDialog({ open, onClose }) {
           type={isHidden && 'password'}
           variant="outlined"
           margin="normal"
-          value={bs58.encode(wallet.provider.account.secretKey)}
+          value={keyOutput}
+        />
+        <FormControlLabel
+          control={
+            <Switch
+              checked={isArrayFormat}
+              onChange={() => setArrayFormat(!isArrayFormat)}
+            />
+          }
+          label="Array Format"
         />
         <FormControlLabel
           control={

--- a/src/components/ExportAccountDialog.js
+++ b/src/components/ExportAccountDialog.js
@@ -16,7 +16,7 @@ export default function ExportAccountDialog({ open, onClose }) {
   const [isArrayFormat, setArrayFormat] = useState(false);
 
   const keyOutput = isArrayFormat
-    ? `[${[].slice.call(wallet.provider.account.secretKey)}]`
+    ? `[${Array.from(wallet.provider.account.secretKey)}]`
     : bs58.encode(wallet.provider.account.secretKey);
 
   return (

--- a/src/components/ExportAccountDialog.js
+++ b/src/components/ExportAccountDialog.js
@@ -13,11 +13,7 @@ import { useWallet } from '../utils/wallet';
 export default function ExportAccountDialog({ open, onClose }) {
   const wallet = useWallet();
   const [isHidden, setIsHidden] = useState(true);
-  const [isArrayFormat, setArrayFormat] = useState(false);
-
-  const keyOutput = isArrayFormat
-    ? `[${Array.from(wallet.provider.account.secretKey)}]`
-    : bs58.encode(wallet.provider.account.secretKey);
+  const keyOutput = `[${Array.from(wallet.provider.account.secretKey)}]`;
 
   return (
     <DialogForm open={open} onClose={onClose} fullWidth>
@@ -30,16 +26,6 @@ export default function ExportAccountDialog({ open, onClose }) {
           variant="outlined"
           margin="normal"
           value={keyOutput}
-        />
-        {isArrayFormat && <p>Developer feature - array format cannot be imported directly.</p>}
-        <FormControlLabel
-          control={
-            <Switch
-              checked={isArrayFormat}
-              onChange={() => setArrayFormat(!isArrayFormat)}
-            />
-          }
-          label="Array Format"
         />
         <FormControlLabel
           control={

--- a/src/components/ExportAccountDialog.js
+++ b/src/components/ExportAccountDialog.js
@@ -6,7 +6,6 @@ import DialogContent from '@material-ui/core/DialogContent';
 import TextField from '@material-ui/core/TextField';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Switch from '@material-ui/core/Switch';
-import * as bs58 from 'bs58';
 import DialogForm from './DialogForm';
 import { useWallet } from '../utils/wallet';
 


### PR DESCRIPTION
Changes things such that you can only import/export accounts using the array format used in Solana at `~/.config/solana/id.json` and other places.

- Fixes: https://github.com/project-serum/spl-token-wallet/issues/66
- Fixes: https://github.com/project-serum/spl-token-wallet/issues/55

