### PR TITLE
Feature/custom endpoint

### DIFF
--- a/src/components/CustomEndpointsDialog.js
+++ b/src/components/CustomEndpointsDialog.js
@@ -4,6 +4,7 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogForm from './DialogForm';
 import TextField from '@material-ui/core/TextField';
+import FormHelperText from '@material-ui/core/FormHelperText';
 
 export default function CustomEndpointsDialog({
   customEndpoints,
@@ -13,6 +14,7 @@ export default function CustomEndpointsDialog({
   onClose,
 }) {
   const [userInput, setUserInput] = useState('');
+  const [hasError, setHasError] = useState(false);
 
   return (
     <DialogForm
@@ -25,38 +27,71 @@ export default function CustomEndpointsDialog({
     >
       <DialogTitle>Manage Custom Endpoints</DialogTitle>
       <DialogContent>
-        {customEndpoints.map((endpoint) => {
-          return (
-            <div key={endpoint}>
-              {endpoint}{' '}
-              <Button
-                type="submit"
-                color="primary"
-                onClick={() => onRemove(endpoint)}
+        <div
+          style={{
+            width: 'fit-content',
+            marginBottom: '8px',
+            maxWidth: '100%',
+          }}
+        >
+          {customEndpoints.map((endpoint) => {
+            return (
+              <div
+                key={endpoint}
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                }}
               >
-                Remove
-              </Button>
-            </div>
-          );
-        })}
+                {endpoint}{' '}
+                <Button
+                  type="submit"
+                  color="primary"
+                  onClick={() => onRemove(endpoint)}
+                  style={{ marginLeft: '8px' }}
+                >
+                  Remove
+                </Button>
+              </div>
+            );
+          })}
+        </div>
         <div style={{ display: 'flex', paddingTop: '16px' }}>
           <TextField
+            error={hasError}
             label="Custom Endpoint"
             fullWidth
             variant="outlined"
             placeholder="e.g. https://solana-api.projectserum.com"
             value={userInput}
-            onChange={(e) => setUserInput(e.target.value)}
+            onChange={(e) => {
+              setUserInput(e.target.value);
+              setHasError(false);
+            }}
             style={{ marginRight: '16px' }}
           />
           <Button
             type="submit"
             color="primary"
-            onClick={() => onAdd(userInput)}
+            onClick={() => {
+              const valid = userInput.match(/^(http|https):\/\//);
+              if (!valid) {
+                setHasError(true);
+              } else {
+                onAdd(userInput);
+                setUserInput('');
+              }
+            }}
           >
             Add
           </Button>
         </div>
+        {hasError && (
+          <FormHelperText error>
+            Endpoint must start with http:// or https://
+          </FormHelperText>
+        )}
 
         <div
           style={{

--- a/src/components/CustomEndpointsDialog.js
+++ b/src/components/CustomEndpointsDialog.js
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import Button from '@material-ui/core/Button';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogForm from './DialogForm';
+import TextField from '@material-ui/core/TextField';
+
+export default function CustomEndpointsDialog({
+  customEndpoints,
+  open,
+  onAdd,
+  onRemove,
+  onClose,
+}) {
+  const [userInput, setUserInput] = useState('');
+
+  return (
+    <DialogForm
+      open={open}
+      onEnter={() => {}}
+      onClose={() => {
+        onClose();
+      }}
+      fullWidth
+    >
+      <DialogTitle>Manage Custom Endpoints</DialogTitle>
+      <DialogContent>
+        {customEndpoints.map((endpoint) => {
+          return (
+            <div key={endpoint}>
+              {endpoint}{' '}
+              <Button
+                type="submit"
+                color="primary"
+                onClick={() => onRemove(endpoint)}
+              >
+                Remove
+              </Button>
+            </div>
+          );
+        })}
+        <div style={{ display: 'flex', paddingTop: '16px' }}>
+          <TextField
+            label="Custom Endpoint"
+            fullWidth
+            variant="outlined"
+            placeholder="e.g. https://solana-api.projectserum.com"
+            value={userInput}
+            onChange={(e) => setUserInput(e.target.value)}
+            style={{ marginRight: '16px' }}
+          />
+          <Button
+            type="submit"
+            color="primary"
+            onClick={() => onAdd(userInput)}
+          >
+            Add
+          </Button>
+        </div>
+
+        <div
+          style={{
+            padding: '16px 0 4px',
+            display: 'flex',
+            justifyContent: 'center',
+          }}
+        >
+          <Button
+            onClick={() => {
+              setUserInput('');
+              onClose();
+            }}
+          >
+            Close
+          </Button>
+        </div>
+      </DialogContent>
+    </DialogForm>
+  );
+}

--- a/src/components/CustomEndpointsDialog.js
+++ b/src/components/CustomEndpointsDialog.js
@@ -46,7 +46,6 @@ export default function CustomEndpointsDialog({
               >
                 {endpoint}{' '}
                 <Button
-                  type="submit"
                   color="primary"
                   onClick={() => onRemove(endpoint)}
                   style={{ marginLeft: '8px' }}

--- a/src/components/NavigationFrame.js
+++ b/src/components/NavigationFrame.js
@@ -79,6 +79,7 @@ function NetworkSelector() {
 
   const networks = [
     MAINNET_URL,
+    'https://api.mainnet-beta.solana.com',
     clusterApiUrl('devnet'),
     clusterApiUrl('testnet'),
     'http://localhost:8899',
@@ -86,8 +87,10 @@ function NetworkSelector() {
 
   const networkLabels = {
     [MAINNET_URL]: 'Mainnet Beta',
+    'https://api.mainnet-beta.solana.com': 'Mainnet Beta',
     [clusterApiUrl('devnet')]: 'Devnet',
     [clusterApiUrl('testnet')]: 'Testnet',
+    'http://localhost:8899': 'Local Validator',
   };
 
   return (
@@ -120,7 +123,7 @@ function NetworkSelector() {
           onClick={(e) => setAnchorEl(e.target)}
           className={classes.button}
         >
-          {networkLabels[endpoint] ?? 'Network'}
+          {networkLabels[endpoint] ?? 'Custom Network'}
         </Button>
       </Hidden>
       <Hidden smUp>

--- a/src/components/NavigationFrame.js
+++ b/src/components/NavigationFrame.js
@@ -106,7 +106,7 @@ function NetworkSelector() {
         }}
         onRemove={(customEndpoint) => {
           // If user removes the selected endpoint, default back to the mainnet endpoint
-          if (customEndpoint == endpoint) {
+          if (customEndpoint === endpoint) {
             setEndpoint(networks[0]);
           }
           setCustomNetworks(
@@ -174,6 +174,7 @@ function NetworkSelector() {
           onClick={() => {
             setManageCustomEndpointsOpen(true);
           }}
+          style={{ paddingLeft: '48px' }}
         >
           {'Manage custom endpoints...'}
         </MenuItem>

--- a/src/components/NavigationFrame.js
+++ b/src/components/NavigationFrame.js
@@ -143,22 +143,7 @@ function NetworkSelector() {
         }}
         getContentAnchorEl={null}
       >
-        {networks.map((network) => (
-          <MenuItem
-            key={network}
-            onClick={() => {
-              setAnchorEl(null);
-              setEndpoint(network);
-            }}
-            selected={network === endpoint}
-          >
-            <ListItemIcon className={classes.menuItemIcon}>
-              {network === endpoint ? <CheckIcon fontSize="small" /> : null}
-            </ListItemIcon>
-            {network}
-          </MenuItem>
-        ))}
-        {customNetworks.map((network) => (
+        {[...networks, ...customNetworks].map((network) => (
           <MenuItem
             key={network}
             onClick={() => {

--- a/src/utils/connection.tsx
+++ b/src/utils/connection.tsx
@@ -16,7 +16,6 @@ const ConnectionContext = React.createContext<{
 } | null>(null);
 
 export const MAINNET_URL = 'https://solana-api.projectserum.com';
-
 export function ConnectionProvider({ children }) {
   const [endpoint, setEndpoint] = useLocalStorageState(
     'connectionEndpoint',

--- a/src/utils/connection.tsx
+++ b/src/utils/connection.tsx
@@ -16,6 +16,7 @@ const ConnectionContext = React.createContext<{
 } | null>(null);
 
 export const MAINNET_URL = 'https://solana-api.projectserum.com';
+
 export function ConnectionProvider({ children }) {
   const [endpoint, setEndpoint] = useLocalStorageState(
     'connectionEndpoint',


### PR DESCRIPTION
### Addresses Issue: #72 

### Content:
- Add CustomEndpointsDialogue modal
    - Allows adding custom endpoints
    - Allows removing custom endpoints
    - If the currently active custom endpoint is removed, the mainnet endpoint is selected by default (https://solana-api.projectserum.com)
    - Invalid input rejected with error message (endpoint must start with http:// or https://)
- Add "Manage Custom Endpoints..." to open modal in the network dropdown
- Custom endpoints persisted in local storage
- Add new constant endpoint (https://api.mainnet-beta.solana.com)
- Update network labels

### Screen recording:

https://user-images.githubusercontent.com/9023427/106411682-d2e03f80-6413-11eb-8259-8eb798294df6.mp4

