### PR TITLE
Create associated token program accounts when sending

### DIFF
--- a/src/utils/notifications.js
+++ b/src/utils/notifications.js
@@ -40,7 +40,7 @@ export function useSendTransaction() {
     } catch (e) {
       closeSnackbar(id);
       setSending(false);
-      console.warn(e.message);
+      console.warn(e);
       enqueueSnackbar(e.message, { variant: 'error' });
       if (onError) {
         onError(e);


### PR DESCRIPTION
When sending SPL tokens to a system-program-owned account, automatically create and send to the associated token program account instead.