### PR TITLE
Attempt at deobfuscating unknown instruction approval

### DIFF
--- a/src/components/instructions/UnknownInstruction.js
+++ b/src/components/instructions/UnknownInstruction.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import LabelValue from './LabelValue';
 import Typography from '@material-ui/core/Typography';
 
-export default function UnknownInstruction({ instruction }) {
+export default function UnknownInstruction({ instruction, onOpenAddress }) {
   return (
     <>
       <Typography
@@ -11,8 +12,26 @@ export default function UnknownInstruction({ instruction }) {
       >
         Unknown instruction:
       </Typography>
+      {instruction.accounts.map((accountAddress, index) => {
+          return (
+            <LabelValue
+              key={index + ''}
+              label={'Account #' + (index + 1)}
+              value={accountAddress?.toBase58()}
+              link={true}
+              onClick={() => onOpenAddress(accountAddress?.toBase58())}
+            />
+          );
+        })}
+      <LabelValue
+        key='Program Id'
+        label='Program Id:'
+        value={instruction.programId?.toBase58()}
+        link={true}
+        onClick={() => onOpenAddress(instruction.programId?.toBase58())}
+      />
       <Typography style={{ wordBreak: 'break-all' }}>
-        {instruction?.rawData}
+        data: {instruction.data}
       </Typography>
     </>
   );

--- a/src/components/instructions/UnknownInstruction.js
+++ b/src/components/instructions/UnknownInstruction.js
@@ -12,23 +12,26 @@ export default function UnknownInstruction({ instruction, onOpenAddress }) {
       >
         Unknown instruction:
       </Typography>
-      {instruction.accounts.map((accountAddress, index) => {
+      {instruction.accountMetas.map((accountMeta, index) => {
           return (
-            <LabelValue
-              key={index + ''}
-              label={'Account #' + (index + 1)}
-              value={accountAddress?.toBase58()}
-              link={true}
-              onClick={() => onOpenAddress(accountAddress?.toBase58())}
-            />
+            <>
+              <LabelValue
+                key={index + ''}
+                label={'Account #' + (index + 1)}
+                value={accountMeta.publicKey.toBase58()}
+                link={true}
+                onClick={() => onOpenAddress(accountMeta.publicKey.toBase58())}
+              />
+              <Typography gutterBottom>isWritable: {accountMeta.isWritable.toString()}</Typography>
+            </>
           );
         })}
       <LabelValue
         key='Program Id'
-        label='Program Id:'
+        label='Program Id'
         value={instruction.programId?.toBase58()}
         link={true}
-        onClick={() => onOpenAddress(instruction.programId?.toBase58())}
+        onClick={() => onOpenAddress(instruction.programId.toBase58())}
       />
       <Typography style={{ wordBreak: 'break-all' }}>
         data: {instruction.rawData}

--- a/src/components/instructions/UnknownInstruction.js
+++ b/src/components/instructions/UnknownInstruction.js
@@ -12,6 +12,13 @@ export default function UnknownInstruction({ instruction, onOpenAddress }) {
       >
         Unknown instruction:
       </Typography>
+      <LabelValue
+        key='Program'
+        label='Program'
+        value={instruction.programId?.toBase58()}
+        link={true}
+        onClick={() => onOpenAddress(instruction.programId.toBase58())}
+      />
       {instruction.accountMetas.map((accountMeta, index) => {
           return (
             <>
@@ -26,15 +33,8 @@ export default function UnknownInstruction({ instruction, onOpenAddress }) {
             </>
           );
         })}
-      <LabelValue
-        key='Program Id'
-        label='Program Id'
-        value={instruction.programId?.toBase58()}
-        link={true}
-        onClick={() => onOpenAddress(instruction.programId.toBase58())}
-      />
       <Typography style={{ wordBreak: 'break-all' }}>
-        data: {instruction.rawData}
+        Data: {instruction.rawData}
       </Typography>
     </>
   );

--- a/src/components/instructions/UnknownInstruction.js
+++ b/src/components/instructions/UnknownInstruction.js
@@ -31,7 +31,7 @@ export default function UnknownInstruction({ instruction, onOpenAddress }) {
         onClick={() => onOpenAddress(instruction.programId?.toBase58())}
       />
       <Typography style={{ wordBreak: 'break-all' }}>
-        data: {instruction.data}
+        data: {instruction.rawData}
       </Typography>
     </>
   );

--- a/src/pages/PopupPage.js
+++ b/src/pages/PopupPage.js
@@ -502,7 +502,7 @@ function ApproveSignatureForm({
           <NewOrder instruction={instruction} onOpenAddress={onOpenAddress} v3={true} />
         );
       default:
-        return <UnknownInstruction instruction={instruction} />;
+        return <UnknownInstruction instruction={instruction} onOpenAddress={onOpenAddress} />;
     }
   };
 

--- a/src/utils/transactions.js
+++ b/src/utils/transactions.js
@@ -46,6 +46,7 @@ export const decodeMessage = async (connection, wallet, message) => {
       publicKey,
       transactionMessage?.accountKeys,
       transactionInstruction,
+      transactionMessage,
       i,
     );
     instructions.push({
@@ -61,6 +62,7 @@ const toInstruction = async (
   publicKey,
   accountKeys,
   instruction,
+  transactionMessage,
   index,
 ) => {
   if (
@@ -130,7 +132,10 @@ const toInstruction = async (
     } else {
       return {
         type: 'Unknown',
-        accounts: instruction.accounts.map(index => accountKeys[index]),
+        accountMetas: instruction.accounts.map(index => ({
+            publicKey: accountKeys[index],
+            isWritable: transactionMessage.isAccountWritable(index)
+        })),
         programId
       }
     }

--- a/src/utils/transactions.js
+++ b/src/utils/transactions.js
@@ -50,7 +50,7 @@ export const decodeMessage = async (connection, wallet, message) => {
     );
     instructions.push({
       ...instruction,
-      rawData: transactionInstruction?.data,
+      data: transactionInstruction?.data,
     });
   }
   return instructions;
@@ -127,6 +127,12 @@ const toInstruction = async (
         accountKeys,
         decodedInstruction,
       );
+    } else {
+      return {
+        type: 'Unknown',
+        accounts: instruction.accounts.map(index => accountKeys[index]),
+        programId
+      }
     }
   } catch {}
 

--- a/src/utils/transactions.js
+++ b/src/utils/transactions.js
@@ -50,7 +50,7 @@ export const decodeMessage = async (connection, wallet, message) => {
     );
     instructions.push({
       ...instruction,
-      data: transactionInstruction?.data,
+      rawData: transactionInstruction?.data,
     });
   }
   return instructions;


### PR DESCRIPTION
That is how it looks like.
![image](https://user-images.githubusercontent.com/8245419/110536520-abe4fe00-8175-11eb-803f-a9d8bffeff54.png)


I think each account should be enriched to display isWritable and isSigner for each account. I will investigate how to do that.

for isWritable it seems we can get it from https://solana-labs.github.io/solana-web3.js/class/src/message.js~Message.html#instance-method-isAccountWritable

I also need to check how it looks when there are multiple unknown instructions

#91 