### PR TITLE
Display token accounts less prominently

### DIFF
--- a/src/components/DepositDialog.js
+++ b/src/components/DepositDialog.js
@@ -36,6 +36,7 @@ export default function DepositDialog({
   publicKey,
   balanceInfo,
   swapInfo,
+  isAssociatedToken,
 }) {
   const ethAccount = useEthAccount();
   const urlSuffix = useSolanaExplorerUrlSuffix();
@@ -66,9 +67,12 @@ export default function DepositDialog({
       </Tabs>
     );
   }
-
+  const displaySolAddress = publicKey.equals(owner) || isAssociatedToken;
+  const depositAddressStr = displaySolAddress
+    ? owner.toBase58()
+    : publicKey.toBase58();
   return (
-    <DialogForm open={open} onClose={onClose}>
+    <DialogForm open={open} onClose={onClose} maxWidth="sm" fullWidth>
       <DialogTitle>
         Deposit {tokenName ?? mint.toBase58()}
         {tokenSymbol ? ` (${tokenSymbol})` : null}
@@ -84,20 +88,20 @@ export default function DepositDialog({
       <DialogContent style={{ paddingTop: 16 }}>
         {tab === 0 ? (
           <>
-            {publicKey.equals(owner) ? (
-              <DialogContentText>
-                This address can only be used to receive SOL. Do not send other
-                tokens to this address.
-              </DialogContentText>
-            ) : (
+            {!displaySolAddress && isAssociatedToken === false ? (
               <DialogContentText>
                 This address can only be used to receive{' '}
                 {tokenSymbol ?? abbreviateAddress(mint)}. Do not send SOL to
                 this address.
               </DialogContentText>
+            ) : (
+              <DialogContentText>
+                This address can be used to receive{' '}
+                {tokenSymbol ?? abbreviateAddress(mint)}.
+              </DialogContentText>
             )}
             <CopyableDisplay
-              value={publicKey.toBase58()}
+              value={depositAddressStr}
               label={'Deposit Address'}
               autoFocus
               qrCode
@@ -105,7 +109,7 @@ export default function DepositDialog({
             <DialogContentText variant="body2">
               <Link
                 href={
-                  `https://explorer.solana.com/account/${publicKey.toBase58()}` +
+                  `https://explorer.solana.com/account/${depositAddressStr}` +
                   urlSuffix
                 }
                 target="_blank"

--- a/src/components/MergeAccountsDialog.js
+++ b/src/components/MergeAccountsDialog.js
@@ -168,11 +168,11 @@ export default function MergeAccountsDialog({ open, onClose }) {
         </DialogContent>
       ) : (
         <>
-          <DialogTitle>Are you sure you want to merge accounts?</DialogTitle>
+          <DialogTitle>Are you sure you want to merge tokens?</DialogTitle>
           <DialogContent>
             <DialogContentText>
               <b>WARNING</b>: This action may break apps that depend on your
-              existing accounts.
+              existing token accounts.
             </DialogContentText>
             <DialogContentText>
               Merging sends all tokens to{' '}

--- a/src/utils/markets.ts
+++ b/src/utils/markets.ts
@@ -7,7 +7,7 @@ interface Markets {
     publicKey: PublicKey;
     name: string;
     deprecated?: boolean;
-  }
+  };
 }
 
 export const serumMarkets = (() => {
@@ -34,7 +34,7 @@ export const serumMarkets = (() => {
 
 // Create a cached API wrapper to avoid rate limits.
 class PriceStore {
-  cache: {}
+  cache: {};
 
   constructor() {
     this.cache = {};
@@ -50,7 +50,12 @@ class PriceStore {
         fetch(`https://serum-api.bonfida.com/orderbooks/${marketName}`).then(
           (resp) => {
             resp.json().then((resp) => {
-              if (resp.data.asks.length === 0 && resp.data.bids.length === 0) {
+              if (resp.data.asks === null || resp.data.bids === null) {
+                resolve(undefined);
+              } else if (
+                resp.data.asks.length === 0 &&
+                resp.data.bids.length === 0
+              ) {
                 resolve(undefined);
               } else if (resp.data.asks.length === 0) {
                 resolve(resp.data.bids[0].price);


### PR DESCRIPTION
A bunch of misc UI changes that further encourages the use of SOL accounts and associated token addresses, so that we can take one step closer to a world where the only address shown by sollet is the SOL address.

### Changes

* Don't display token address in main balance list item 
* Rename "Deposit address" in balance list item to "Token Metadata" to discourage its use (and encourage the user to click "Receive"). Hide it for SOL.
* For all associated token accounts, display the SOL address as the "Receive" deposit address. Non associated token accounts show the token account address.
* Only show the deposit dialog's scary "This address can only be used to receive XXX" message for non-associated token accounts. This is to avoid confusion, since SPL tokens can indeed be sent to SOL addresses.
* Display message encouraging the user to merge, when balance details for non associated tokens are opened.