### PR TITLE
fix 'sign' method in Chrome extension context

### DIFF
--- a/extension/src/manifest.json
+++ b/extension/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Sollet",
   "description": "Solana SPL Token Wallet",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "browser_action": {
     "default_popup": "index.html",
     "default_title": "Open the popup"

--- a/src/pages/PopupPage.js
+++ b/src/pages/PopupPage.js
@@ -35,7 +35,23 @@ function getInitialRequests() {
   // TODO CHECK OPENER (?)
 
   const urlParams = new URLSearchParams(window.location.hash.slice(1));
-  return [JSON.parse(urlParams.get('request'))];
+  const request = JSON.parse(urlParams.get('request'));
+  
+  if (request.method === 'sign') {
+    const dataObj = request.params.data;
+    // Deserialize `data` into a Uint8Array
+    if (!dataObj) {
+      throw new Error('Missing "data" params for "sign" request');
+    }
+
+    const data = new Uint8Array(Object.keys(dataObj).length);
+    for (const [index, value] of Object.entries(dataObj)) {
+      data[index] = value;
+    }
+    request.params.data = data;
+  }
+
+  return [request];
 }
 
 export default function PopupPage({ opener }) {


### PR DESCRIPTION
Address https://github.com/project-serum/spl-token-wallet/issues/161
When the request is serialized in the URL, the Uint8Array becomes an object that needs to be deserialized back into a Uint8Array, which is what this patch does.