### PR TITLE
Switch to web3.js getProgramAccounts: Fix for devnet and ultimately mainnet

### DIFF
--- a/src/utils/tokens/index.js
+++ b/src/utils/tokens/index.js
@@ -20,9 +20,9 @@ import { ACCOUNT_LAYOUT, getOwnedAccountsFilters, MINT_LAYOUT } from './data';
 
 export async function getOwnedTokenAccounts(connection, publicKey) {
   let filters = getOwnedAccountsFilters(publicKey);
-  let resp = await connection.getProgramAccounts(TOKEN_PROGRAM_ID,
+  let resp = await connection.getProgramAccounts(
+    TOKEN_PROGRAM_ID,
     {
-      commitment: connection.commitment,
       filters,
     },
   );

--- a/src/utils/tokens/index.js
+++ b/src/utils/tokens/index.js
@@ -17,17 +17,15 @@ import {
   transferChecked,
 } from './instructions';
 import { ACCOUNT_LAYOUT, getOwnedAccountsFilters, MINT_LAYOUT } from './data';
-import bs58 from 'bs58';
 
 export async function getOwnedTokenAccounts(connection, publicKey) {
   let filters = getOwnedAccountsFilters(publicKey);
-  let resp = await connection._rpcRequest('getProgramAccounts', [
-    TOKEN_PROGRAM_ID.toBase58(),
+  let resp = await connection.getProgramAccounts(TOKEN_PROGRAM_ID,
     {
       commitment: connection.commitment,
       filters,
     },
-  ]);
+  );
   if (resp.error) {
     throw new Error(
       'failed to get token accounts owned by ' +
@@ -36,33 +34,16 @@ export async function getOwnedTokenAccounts(connection, publicKey) {
         resp.error.message,
     );
   }
-  return resp.result
+  return resp
     .map(({ pubkey, account: { data, executable, owner, lamports } }) => ({
       publicKey: new PublicKey(pubkey),
       accountInfo: {
-        data: bs58.decode(data),
+        data,
         executable,
         owner: new PublicKey(owner),
         lamports,
       },
     }))
-    .filter(({ accountInfo }) => {
-      // TODO: remove this check once mainnet is updated
-      return filters.every((filter) => {
-        if (filter.dataSize) {
-          return accountInfo.data.length === filter.dataSize;
-        } else if (filter.memcmp) {
-          let filterBytes = bs58.decode(filter.memcmp.bytes);
-          return accountInfo.data
-            .slice(
-              filter.memcmp.offset,
-              filter.memcmp.offset + filterBytes.length,
-            )
-            .equals(filterBytes);
-        }
-        return false;
-      });
-    });
 }
 
 export async function signAndSendTransaction(

--- a/src/utils/tokens/index.js
+++ b/src/utils/tokens/index.js
@@ -26,14 +26,6 @@ export async function getOwnedTokenAccounts(connection, publicKey) {
       filters,
     },
   );
-  if (resp.error) {
-    throw new Error(
-      'failed to get token accounts owned by ' +
-        publicKey.toBase58() +
-        ': ' +
-        resp.error.message,
-    );
-  }
   return resp
     .map(({ pubkey, account: { data, executable, owner, lamports } }) => ({
       publicKey: new PublicKey(pubkey),


### PR DESCRIPTION
I believe this to be a cleaner fix than #350 

Not sure what to do with:
https://github.com/project-serum/spl-token-wallet/blob/bdeebe90cfadcba8782e2ebe70cdc406b5d781e2/src/utils/tokens/index.js#L29-L36
Do we want a try/catch? web3.js naturally throws, maybe we let it throw?