### PR TITLE
added stSOL to popular token list

### DIFF
--- a/src/utils/tokens/names.js
+++ b/src/utils/tokens/names.js
@@ -278,6 +278,13 @@ const POPULAR_TOKENS = {
       icon:
         'https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU/logo.png',
     },
+    {
+      tokenSymbol: 'stSOL',
+      mintAddress: '7dHbWXmci3dT8UFYWYZweBLXgycu7Y3iL6trKn1Y7ARj',
+      tokenName: 'Lido Staked SOL',
+      icon:
+        'https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/7dHbWXmci3dT8UFYWYZweBLXgycu7Y3iL6trKn1Y7ARj/logo.png',
+    },
   ],
 };
 


### PR DESCRIPTION
Lido for Solana’ is a Lido-DAO governed liquid staking protocol for the Solana blockchain. stSOL is its liquid staking token that will accrue staking rewards and represent staking positions with Lido validators on Solana. 
Anyone who stakes their SOL tokens with Lido will be issued an on-chain representation of their SOL staking position with Lido validators, called stSOL.

For more information on the project roadmap please visit - https://medium.com/chorus-one/project-roadmap-lido-for-solana-88e6a20950c5
To know more about Lido please visit - https://lido.fi/