### PR TITLE
properly print transactions with empty data

### DIFF
--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -73,7 +73,7 @@ const toInstruction = async (
   index: number,
 ) => {
   if (
-    !instruction?.data ||
+    instruction?.data == null ||
     !instruction?.accounts ||
     !instruction?.programIdIndex
   ) {


### PR DESCRIPTION
`toInstruction` returns undefined if `instruction.data` is the empty string, so account information doesnt print on the approve screen for instructions that require no data. should only happen when data is null or undefined